### PR TITLE
Fixes for Hobbs & Shaw

### DIFF
--- a/fast.js
+++ b/fast.js
@@ -8,7 +8,7 @@
         root.r_fast_r_furious = factory();
   }
 }(this, function () {
-    var r_fast = /^((T(he)(?!.*\d)(?=.*the)|2(?=.* 2)) )?(((Hobbs(?=.+A)|Fate(?=.+of)(?!.*S)|Fast(?!.*7)) )?(Five|((((of|and) t\3)|And(?=.+w)|\2(?=.*s$)|&(?!.*:)) )?((Furious)|(Shaw))(( (6|7))|: Tokyo Drift)?))$/;
+    var r_fast = /^((T(he)(?!.*\d)(?=.*the)|2(?=.* 2)) )?(((Fast and Furious Presents: Hobbs(?=.+&)|Fate(?=.+of)(?!.*S)|Fast(?!.*7)) )?(Five|((((of|and) t\3)|And(?=.+w)|\2(?=.*s$)|&(?!.*:)) )?((Furious)|(Shaw))(( (6|7))|: Tokyo Drift)?))$/;
 
     return function (str) {
         return r_fast.test(str);

--- a/test.js
+++ b/test.js
@@ -25,7 +25,7 @@ assert(fast('Furious 7'));
 
 assert(fast('The Fate of the Furious'));
 
-assert(fast('Hobbs And Shaw'));
+assert(fast('Fast and Furious Presents: Hobbs & Shaw'));
 
 assert(! fast('Fast & Furious 100: Electric Boogaloo'));
 
@@ -47,6 +47,10 @@ assert(! fast('The Fast and the Furious 6'));
 
 assert(! fast('Fast & Furious 7'));
 
+assert(! fast('Hobbs And Shaw'));
+
+assert(! fast('Hobbs & Shaw'));
+
 assert(! fast('Hobbs And Furious'));
 
 assert(! fast('The Hobbs and the Shaw'));
@@ -54,6 +58,8 @@ assert(! fast('The Hobbs and the Shaw'));
 assert(! fast('The Furious'));
 
 assert(! fast('The Fate of the Shaw'));
+
+assert(! fast('Fast and Furious Presents'));
 
 /*
  * TODO: fix these false positives


### PR DESCRIPTION
The title appears as  `Fast and Furious Presents: Hobbs & Shaw` during the opening credits, so based on previous discussion (https://github.com/alunny/r_fast_r_furious/issues/6#issuecomment-460484329) I made it the only valid title.

This could use some refactoring if there are future movies prefixed with `Fast and Furious Presents:` but I believe this be ok for now.